### PR TITLE
Update VMIMAGE in batch_handler.py

### DIFF
--- a/src/hpcadvisor/batch_handler.py
+++ b/src/hpcadvisor/batch_handler.py
@@ -29,7 +29,7 @@ from hpcadvisor.azure_identity_credential_adapter import \
     AzureIdentityCredentialAdapter
 
 batch_supported_images = "batch_supported_images.txt"
-VMIMAGE = "almalinux:almalinux-hpc:8_6-hpc-gen2:latest"
+VMIMAGE = "almalinux:almalinux-hpc:8-hpc-gen2:latest"
 backupnodeagent = "batch.node.el 8"
 anfenabled = True
 env = {}


### PR DESCRIPTION
alma-hpc 8.6 image is deprecated.  using just `8-hpc-gen2` for the image worked for me.